### PR TITLE
Adding a function to generate post type labels

### DIFF
--- a/generators/install-core/templates/functions/_mttr-misc.php
+++ b/generators/install-core/templates/functions/_mttr-misc.php
@@ -901,3 +901,51 @@ function mttr_add_gravity_forms_editor(){
 
 }
 add_action( 'admin_init','mttr_add_gravity_forms_editor' );
+
+
+
+
+/* ---------------------------------------------------------
+*	Generator for CPT lables
+ ---------------------------------------------------------*/
+
+function mttr_generate_cpt_labels( $single, $plural = null ) {
+
+	if( empty( $plural ) ) {
+
+		if( substr( $single, -1) == 'y' ) {
+
+			$plural = substr( $single, 0, -1) . 'ies';
+
+		} else {
+
+			$plural = $single . 's';
+
+		}
+
+	}
+
+	$labels = array(
+
+		'name' => $plural,
+		'singular_name' => $single,
+		'add_new_item' => 'Add New ' . $single,
+		'edit_item' => 'Edit ' . $single,
+		'new_item' => 'New ' . $single,
+		'view_item' => 'View ' . $single,
+		'view_items' => 'View ' . $plural,
+		'search_items' => 'Search ' . $plural,
+		'not_found' => 'No ' . $plural . ' found',
+		'not_found_in_trash' => 'No ' . $plural . ' found in Trash',
+		'parent_item_colon' => 'Parent ' . $single . ':',
+		'all_items' => 'All ' . $plural,
+		'archives' => $single . ' Archives',
+		'attributes' => $single . ' Attributes',
+		'insert_into_item' => 'Insert into ' . $single,
+		'uploaded_to_this_item' => 'Uploaded to this ' . $single,
+
+	);
+
+	return $labels;
+
+}


### PR DESCRIPTION
Adds function `mttr_generate_cpt_labels` that will generate post type labels for CPTs.

- Accepts both singular and plural arguments
- If plural is not provided it will be generated
- - If single ends in `y` drops the `y` and replaces with `ies`
- - Otherwise just appends `s`
- Returns labels to be used by plugins